### PR TITLE
Add conditionals to actor icon and image

### DIFF
--- a/routes/activitypub/activitypub.ts
+++ b/routes/activitypub/activitypub.ts
@@ -88,16 +88,16 @@ function activityPubRoutes(app: Application) {
           endpoints: {
             sharedInbox: `${environment.frontendUrl}/fediverse/sharedInbox`
           },
-          icon: {
+          ...(user.avatar? {icon: {
             type: 'Image',
             mediaType: 'image/webp',
             url: environment.mediaUrl + user.avatar
-          },
-          image: {
+          }} : undefined),
+          ...(user.headerImage? {image: {
             type: 'Image',
             mediaType: 'image/webp',
             url: environment.mediaUrl + user.headerImage
-          },
+          }} : undefined),
           publicKey: {
             id: `${environment.frontendUrl}/fediverse/blog/${user.url.toLowerCase()}#main-key`,
             owner: `${environment.frontendUrl}/fediverse/blog/${user.url.toLowerCase()}`,


### PR DESCRIPTION
Currently when a user does not have a header or avatar set, the image and icons are set with an invalid url (i.e. `https://media.example.comnull`). This change will omit those properties from the activitypub actor object when not set, instead of including invalid urls.